### PR TITLE
Add FILTER_NOTIFICATIONS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Environment:
   OLLAMA_BASE_URL        Ollama server URL (default: http://localhost:11434/v1)
   LMSTUDIO_BASE_URL      LM Studio server URL (default: http://localhost:1234/v1)
   SPACEMOLT_URL          Override game server URL
+  FILTER_NOTIFICATIONS   Comma-separated notification categories to hide from the LLM
+                         (default: none). Valid: chat, dm, broadcast, combat, trade, info, system.
+                         Example: FILTER_NOTIFICATIONS=chat,trade. Filtered notifications still appear in terminal output.
 ```
 
 ## Supported Models

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -22,6 +22,19 @@ const RESET = "\x1b[0m";
 const BOLD = "\x1b[1m";
 const DIM = "\x1b[2m";
 
+/**
+ * Notification categories to filter from the LLM context (still logged to stdout).
+ * Set via FILTER_NOTIFICATIONS env var as a comma-separated list of categories.
+ * Valid categories: chat, dm, broadcast, combat, trade, info, system
+ * Default: none (all notifications forwarded to the LLM)
+ */
+const FILTERED_CATEGORIES: Set<string> = new Set(
+  (process.env.FILTER_NOTIFICATIONS ?? "")
+    .split(",")
+    .map(s => s.trim())
+    .filter(Boolean)
+);
+
 let debugEnabled = false;
 
 export function setDebug(enabled: boolean): void {
@@ -362,6 +375,7 @@ export function formatNotifications(notifications: unknown[]): string {
   for (const n of notifications) {
     const parsed = parseNotification(n);
     if (!parsed) continue;
+    if (FILTERED_CATEGORIES.has(parsed.category)) continue;
     lines.push(`  > [${parsed.tag}] ${parsed.text}`);
   }
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- Adds `FILTER_NOTIFICATIONS` env var to control which notification categories are excluded from the LLM context
- Filtered notifications still appear in terminal output so the human operator can see them
- Default behavior is unchanged (no filtering) — opt in with e.g. `FILTER_NOTIFICATIONS=chat`
- Valid categories: `chat`, `dm`, `broadcast`, `combat`, `trade`, `info`, `system`

## Motivation
In a galaxy with 300+ automated bots loudly announcing their every move, public chat floods the context window. This lets operators filter out noise while preserving game-relevant notifications like DMs and system messages.

## Test plan
- [ ] Run without `FILTER_NOTIFICATIONS` set — all notifications should reach the LLM (unchanged behavior)
- [ ] Run with `FILTER_NOTIFICATIONS=chat` — public chat should appear in terminal but not in LLM context
- [ ] Run with `FILTER_NOTIFICATIONS=chat,trade` — both categories filtered from LLM
- [ ] Run with `FILTER_NOTIFICATIONS=""` — equivalent to no filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)